### PR TITLE
SF: Bring back support for disabling backpressure propagation

### DIFF
--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -433,6 +433,10 @@ SurfaceFlinger::SurfaceFlinger(Factory& factory) : SurfaceFlinger(factory, SkipI
     mBackpressureGpuComposition = base::GetBoolProperty("debug.sf.enable_gl_backpressure"s, true);
     ALOGI_IF(mBackpressureGpuComposition, "Enabling backpressure for GPU composition");
 
+    property_get("debug.sf.disable_backpressure", value, "0");
+    mPropagateBackpressure = !atoi(value);
+    ALOGI_IF(!mPropagateBackpressure, "Disabling backpressure propagation");
+
     property_get("ro.surface_flinger.supports_background_blur", value, "0");
     bool supportsBlurs = atoi(value);
     mSupportsBlur = supportsBlurs;
@@ -2404,7 +2408,7 @@ bool SurfaceFlinger::commit(TimePoint frameTime, VsyncId vsyncId, TimePoint expe
     // When backpressure propagation is enabled, we want to give a small grace period of 1ms
     // for the present fence to fire instead of just giving up on this frame to handle cases
     // where present fence is just about to get signaled.
-    const int graceTimeForPresentFenceMs = static_cast<int>(
+    const int graceTimeForPresentFenceMs = mPropagateBackpressure && static_cast<int>(
             mBackpressureGpuComposition || !mCompositionCoverage.test(CompositionCoverage::Gpu));
 
     // Pending frames may trigger backpressure propagation.
@@ -2472,7 +2476,7 @@ bool SurfaceFlinger::commit(TimePoint frameTime, VsyncId vsyncId, TimePoint expe
         }
     }
 
-    if (framePending) {
+    if (framePending && mPropagateBackpressure) {
         if (mBackpressureGpuComposition || (hwcFrameMissed && !gpuFrameMissed)) {
             scheduleCommit(FrameHint::kNone);
             return false;

--- a/services/surfaceflinger/SurfaceFlinger.h
+++ b/services/surfaceflinger/SurfaceFlinger.h
@@ -1250,6 +1250,7 @@ private:
 
     bool mLayerCachingEnabled = false;
     bool mBackpressureGpuComposition = false;
+    bool mPropagateBackpressure = true;
 
     LayerTracing mLayerTracing;
     bool mLayerTracingEnabled = false;


### PR DESCRIPTION
Taken from CLO (QSSI 13). Some Qualcomm devices can still benefit from disabling backpressure propagation by setting:

debug.sf.disable_backpressure=1

[adi8900]: Adapted to Android U

Change-Id: I2346a1b314666706e1299b295f13b2cef6e00b4d

Tested, builds and boots fine :D